### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '*.html'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to deploy static HTML content to GitHub Pages
- Triggers on pushes to `main` that modify HTML files or the workflow itself
- Uses the `actions/upload-pages-artifact` + `actions/deploy-pages` pattern as recommended in the issue
- Supports manual dispatch via `workflow_dispatch`
- Includes concurrency control to prevent overlapping deployments

## Setup required

GitHub Pages must be configured on the repository with **Source** set to **GitHub Actions** (Settings > Pages > Source > GitHub Actions). This is a one-time manual step by the repository owner.

Once enabled, the site will be available at: https://herve-quiroz.github.io/visual_testing_data/

## Test plan

- [ ] Verify GitHub Pages is enabled with "GitHub Actions" as the source
- [ ] Merge PR and confirm the workflow runs successfully
- [ ] Visit https://herve-quiroz.github.io/visual_testing_data/test-video.html to verify the page loads
- [ ] Test with query parameters: `?project=nrg&branch=main`

Fixes #3

---
✨ Content generated by Claude AI.