### PR TITLE
Add sub-issues prohibition to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ Only work on issues with the `claude` label and no open dependencies. The `find-
 * NEVER add the `claude` label on a Github issue yourself unless it's requested explicitly
 * NEVER work on an issue that depends on functionality added by another open issue
 
+## Issue Dependencies
+
+* Never use GitHub's sub-issue/parent-issue feature (addSubIssue/removeSubIssue). Use native blocked-by dependencies exclusively.
+
 ## Skill Creation
 
 When creating skills, invoke both `/skill-development` and `/skill-creator` for comprehensive coverage. They provide complementary guidance: `/skill-creator` covers core design principles and conciseness, while `/skill-development` covers writing style rules, trigger descriptions, and validation.


### PR DESCRIPTION
## Summary

- Added "Issue Dependencies" section to CLAUDE.md prohibiting use of GitHub's sub-issue/parent-issue feature
- Rule requires using native blocked-by dependencies exclusively

Part of herve-quiroz/claude_code_environment#283 — defense-in-depth fix to ensure Claude always sees the sub-issues prohibition in context, regardless of skill invocation.

## Test plan

- [ ] Verify CLAUDE.md contains the new "Issue Dependencies" section
- [ ] Verify the rule is clear and actionable

---
✨ Content generated by Claude AI.