### PR TITLE
Add Interactive Mode Git Workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,14 @@ Only work on issues with the `claude` label and no open dependencies. The `find-
 
 When creating skills, invoke both `/skill-development` and `/skill-creator` for comprehensive coverage. They provide complementary guidance: `/skill-creator` covers core design principles and conciseness, while `/skill-development` covers writing style rules, trigger descriptions, and validation.
 
+## Interactive Mode Git Workflow
+
+When running in an interactive session (i.e., a user is directly interacting with Claude Code):
+- Work on the `main` branch directly — do not create feature branches
+- Commit and push changes directly to `main`
+- Only create a branch and PR when the user explicitly asks for one
+- If the task involves large or complex changes, ask the user whether they prefer a direct commit to `main` or a PR
+
 ## Repository-Specific Guidelines
 
 This repository contains artefacts for visual testing from various projects.


### PR DESCRIPTION
## Summary

- Adds an "Interactive Mode Git Workflow" section to CLAUDE.md instructing Claude to work on `main` directly during interactive sessions
- Claude will only create branches/PRs when explicitly asked by the user
- Includes a safety guardrail: Claude should ask for confirmation on large/complex changes

Companion PR to herve-quiroz/claude_code_environment#296 (fixes herve-quiroz/claude_code_environment#293).

## Test plan

- [ ] Verify the new section appears correctly in CLAUDE.md

---
✨ Content generated by Claude AI.