### PR TITLE
Fix monthly audit workflow gh issue create flag

### DIFF
--- a/.github/workflows/monthly-audit.yml
+++ b/.github/workflows/monthly-audit.yml
@@ -118,13 +118,12 @@ jobs:
           Reference: #134
           EOF
 
-          # Create the issue
-          issue_number=$(gh issue create \
+          # Create the issue and extract number from the returned URL
+          issue_url=$(gh issue create \
             --title "Monthly Workflow Audit - ${{ steps.period.outputs.month_year }}" \
             --body-file issue_body.md \
-            --label "claude,discuss" \
-            --json number \
-            --jq '.number')
+            --label "claude,discuss")
+          issue_number=$(echo "$issue_url" | grep -o '[0-9]*$')
 
           echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

- Fix `gh issue create` call in Monthly Workflow Audit workflow that used unsupported `--json`/`--jq` flags
- The `gh issue create` command outputs the issue URL to stdout — extract the issue number from that URL instead

## Root Cause

The workflow at `.github/workflows/monthly-audit.yml` line 122-127 used `--json number --jq '.number'` with `gh issue create`, but unlike `gh issue list` or `gh pr view`, the `create` subcommand does not support JSON output flags. This caused the workflow to fail every time it ran.

## Fix

Replace the `--json`/`--jq` approach with URL parsing: capture the URL returned by `gh issue create` and extract the trailing issue number with `grep -o '[0-9]*$'`.

## Test Plan

- [ ] Re-run the Monthly Workflow Audit workflow via `workflow_dispatch` to verify it completes successfully

---
✨ Content generated by Claude AI.