### PR TITLE
Remove commit_and_push and switch_to_main_branch slash commands

### DIFF
--- a/.claude/commands/commit_and_push.md
+++ b/.claude/commands/commit_and_push.md
@@ -1,1 +1,0 @@
-Commit the current changes with a commit message that reflects the changes and push to the repository.

--- a/.claude/commands/switch_to_main_branch.md
+++ b/.claude/commands/switch_to_main_branch.md
@@ -1,1 +1,0 @@
-Switch to the main Git branch and pull changes


### PR DESCRIPTION
## Summary

Removes the `commit_and_push` and `switch_to_main_branch` slash commands. These were unused interactive conveniences copied into this repo by the `new-repository-setup` automation, and nothing depends on them.

This is part of a cross-repo cleanup tracked in herve-quiroz/claude_code_environment#364, which removes both files from every managed repository.

## Changes

- Delete `.claude/commands/commit_and_push.md`
- Delete `.claude/commands/switch_to_main_branch.md`

---
✨ Content generated by Claude AI.