### PR TITLE
Remove Skill Creation section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,6 @@ Only work on issues with the `claude` label and no open dependencies. The `find-
 
 * Never use GitHub's sub-issue/parent-issue feature (addSubIssue/removeSubIssue). Use native blocked-by dependencies exclusively.
 
-## Skill Creation
-
-When creating skills, invoke both `/skill-development` and `/skill-creator` for comprehensive coverage. They provide complementary guidance: `/skill-creator` covers core design principles and conciseness, while `/skill-development` covers writing style rules, trigger descriptions, and validation.
-
 ## Interactive Mode Git Workflow
 
 When running in an interactive session (i.e., a user is directly interacting with Claude Code):


### PR DESCRIPTION
Removes the **Skill Creation** section from `CLAUDE.md`, implementing **Option A** from herve-quiroz/claude_code_environment#375.

## Why

The section pointed to the self-triggering `/skill-development` and `/skill-creator` plugin skills. Those are global plugins available in every session and fire on their own when a skill is genuinely authored — the per-repo reminder is not what makes them trigger. Skills are only ever created in the `claude_code_environment` repo (under `plugins/*`), so keeping this as *universal* guidance added audit surface across all managed repos for guidance relevant to just one.

This is one of the per-repo cleanup PRs tracked by herve-quiroz/claude_code_environment#375.

---
✨ Content generated by Claude AI.